### PR TITLE
Linked files shouldn't be touched before linked dirs creation

### DIFF
--- a/lib/capistrano/tasks/touch-linked-files.rake
+++ b/lib/capistrano/tasks/touch-linked-files.rake
@@ -12,7 +12,6 @@ namespace :linked_files do
     end
   end
 
-  before 'deploy:check:make_linked_dirs', 'linked_files:touch'
   before 'deploy:check:linked_files', 'linked_files:touch'
 
 end


### PR DESCRIPTION
If file isn't placed in the top level directory, it's parent dir will not be created and `touch` will fail.

For example, basic rails project layout:

> *\* Invoke deploy:check:make_linked_dirs (first_time)
> *\* Invoke linked_files:touch (first_time)
> *\* Execute linked_files:touch
> DEBUG [34b2aa19] Running /usr/bin/env if test ! -d /opt/prj/shared; then echo "Directory does not exist '/opt/prj/shared'" 1>&2; false; fi on x.amazonaws.com
> DEBUG [34b2aa19] Command: if test ! -d /opt/prj/shared; then echo "Directory does not exist '/opt/prj/shared'" 1>&2; false; fi
> DEBUG [34b2aa19] Finished in 1.586 seconds with exit status 0 (successful).
> INFO [9dc9bb3e] Running /usr/bin/env touch config/database.yml on x.amazonaws.com
> DEBUG [9dc9bb3e] Command: cd /opt/prj/shared && /usr/bin/env touch config/database.yml
> DEBUG [9dc9bb3e] touch:
> DEBUG [9dc9bb3e] cannot touch `config/database.yml'
> DEBUG [9dc9bb3e] : No such file or directory
> DEBUG [9dc9bb3e]
> cap aborted!
